### PR TITLE
Add Support for newest versions of Tugabrowser

### DIFF
--- a/src/com/jt5/xposed/chromepie/settings/PieSettings.java
+++ b/src/com/jt5/xposed/chromepie/settings/PieSettings.java
@@ -35,6 +35,7 @@ public class PieSettings extends PreferenceActivity {
         "com.metalasfook.nochromo",
         "org.chromium.chrome",
         "tugapower.codeaurora.browser",
+        "tugapower.codeaurora.browser.beta",
         "org.notphenom.swe.browser",
         "com.rsbrowser.browser",
         "com.mokee.yubrowser"


### PR DESCRIPTION
The Newer versions of tugabrowser use the beta caf chromium builds, which have a different package name.
