### PR TITLE
Add support for arter97's chromium build, Remove useless tugabrowser.beta

### DIFF
--- a/src/com/jt5/xposed/chromepie/settings/PieSettings.java
+++ b/src/com/jt5/xposed/chromepie/settings/PieSettings.java
@@ -36,11 +36,11 @@ public class PieSettings extends PreferenceActivity {
         "com.metalasfook.nochromo",
         "org.chromium.chrome",
         "tugapower.codeaurora.browser",
-        "tugapower.codeaurora.browser.beta",
         "org.notphenom.swe.browser",
         "com.rsbrowser.browser",
         "com.mokee.yubrowser",
         "com.hsv.freeadblockerbrowser"
+        "com.arter97.swe_browser"
     );
 
     @Override


### PR DESCRIPTION
Tugabrowser's builds all now have the same package name of 
"tugapower.codeaurora.browser", so we can now remove the old name